### PR TITLE
Feature/assets is scroll to bottom

### DIFF
--- a/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager.swift
@@ -204,7 +204,7 @@ extension AssetsManager {
     
     open func imageOfAlbum(at indexPath: IndexPath, size: CGSize, isNeedDegraded: Bool = true, completion: @escaping ((UIImage?) -> Void)) {
         if let fetchResult = fetchMap[sortedAlbumsArray[indexPath.section][indexPath.row].localIdentifier] {
-            if let asset = fetchResult.lastObject {
+            if let asset = pickerConfig.assetsIsScrollToBottom == true ? fetchResult.lastObject : fetchResult.firstObject {
                 imageManager.requestImage(
                     for: asset,
                     targetSize: size,

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
@@ -367,7 +367,11 @@ extension AssetsPhotoViewController {
                 }
             }
             if AssetsManager.shared.assetArray.count > 0 {
-                collectionView.scrollToItem(at: IndexPath(row: AssetsManager.shared.assetArray.count - 1, section: 0), at: .bottom, animated: false)
+                if pickerConfig.assetsIsScrollToBottom == true {
+                    collectionView.scrollToItem(at: IndexPath(row: AssetsManager.shared.assetArray.count - 1, section: 0), at: .bottom, animated: false)
+                } else {
+                    collectionView.scrollToItem(at: IndexPath(row: 0, section: 0), at: .bottom, animated: false)
+                }
             }
         }
     }


### PR DESCRIPTION
AssetsIsScrollToBottom의 제일 큰 의미는, 
사용자에게 앨범의 사진을 보여줄 때, 
첫번째 사진과 마지막 사진 중에 어느 쪽으로 사용자를 유도할지를 결정하는 의미라고 생각합니다.

그래서 저는 저 설정에 따라 앨범에서 보여주는 사진을 변경해보았습니다.
그리고 앨범을 선택한 후에도 AssetsIsScrollToBottom 옵션이 젹용되도록 수정해보았습니다. 