### PR TITLE
Fix warning 'updatedIndexSets' was never mutate

### DIFF
--- a/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift
@@ -60,7 +60,7 @@ extension AssetsManager: PHPhotoLibraryChangeObserver {
     
     func synchronizeAssets(updatedAlbumIndexSets: [IndexSet], fetchMapBeforeChanges: [String: PHFetchResult<PHAsset>], changeInstance: PHChange) {
         
-        var updatedIndexSets = updatedAlbumIndexSets
+        let updatedIndexSets = updatedAlbumIndexSets
         
         // notify changes of assets
         for (section, albums) in fetchedAlbumsArray.enumerated() {


### PR DESCRIPTION
Fix warning : 
```AssetsPickerViewController/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift:63:13: Variable 'updatedIndexSets' was never mutated; consider changing to 'let' constant```