### PR TITLE
Allow pickerConfig to use assetsMinimumSelectionCount as 0

### DIFF
--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
@@ -440,7 +440,7 @@ extension AssetsPhotoViewController {
     
     func updateNavigationStatus() {
         
-        doneButtonItem.isEnabled = selectedArray.count >= (pickerConfig.assetsMinimumSelectionCount > 0 ? pickerConfig.assetsMinimumSelectionCount : 1)
+        doneButtonItem.isEnabled = selectedArray.count >= (pickerConfig.assetsMinimumSelectionCount >= 0 ? pickerConfig.assetsMinimumSelectionCount : 1)
         
         let counts: (imageCount: Int, videoCount: Int) = selectedArray.reduce((0, 0)) { (result, asset) -> (Int, Int) in
             let imageCount = asset.mediaType == .image ? 1 : 0


### PR DESCRIPTION
Previously, setting .pickerConfig.assetsMinimumSelectionCount = 0 did not work.

This change allows the "Done" button to be enabled if the property is set to 0.