### PR TITLE
Added guard for sort and fetch albumsArray

### DIFF
--- a/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift
+++ b/AssetsPickerViewController/Classes/Assets/AssetsManager+Sync.swift
@@ -133,6 +133,8 @@ extension AssetsManager: PHPhotoLibraryChangeObserver {
                 }
             }
             
+            guard section < sortedAlbumsArray.count && section < fetchedAlbumsArray.count else { return }
+
             // update final changes in albums
             var oldSortedAlbums = sortedAlbumsArray[section]
             let newSortedAlbums = sortedAlbums(fromAlbums: fetchedAlbumsArray[section])


### PR DESCRIPTION
This fixes the crash that happens if you scroll fast then click done while the UICollectionView is still scrolling. The crash also seems to happen the first time you are opening an album sometimes. 

This is the original crash we were getting, I also attached more up to date stack trace. This bug is a bit tricky to reproduce. 

### Steps to reproduce:
1. Fresh install (Albums should be full of images to allow scrolling up and down)
2. Launch picker select 1-2 images
3. Scroll up and down that list very fast
4. While the list is still scrolling click the done button

** We have also noticed this crash when swapping between albums fast and clicking the done button.

### Original Crash: https://github.com/DragonCherry/AssetsPickerViewController/issues/40

![image](https://user-images.githubusercontent.com/14999806/77264980-e6f2d680-6c71-11ea-9b31-c8fbf5fa9bfe.png)
