### PR TITLE
assetsIsScrollToBottom' setting not working

### DIFF
--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
@@ -329,9 +329,11 @@ extension AssetsPhotoViewController {
                     })
                 } else {
                     self.collectionView.reloadData()
-                    let item = self.collectionView(self.collectionView, numberOfItemsInSection: 0) - 1
-                    let lastItemIndex = NSIndexPath(item: item, section: 0)
-                    self.collectionView.scrollToItem(at: lastItemIndex as IndexPath, at: .top, animated: false)
+                    if self.pickerConfig.assetsIsScrollToBottom {
+                        let item = self.collectionView(self.collectionView, numberOfItemsInSection: 0) - 1
+                        let lastItemIndex = NSIndexPath(item: item, section: 0)
+                        self.collectionView.scrollToItem(at: lastItemIndex as IndexPath, at: .top, animated: false)
+                    }
                 }
                 self.loadingPlaceholderView.isHidden = true
                 self.loadingActivityIndicatorView.stopAnimating()


### PR DESCRIPTION
Fixed an issue where the 'assetsIsScrollToBottom' setting did not work when starting the picker.