### PR TITLE
Add missing bottom constraint on album cell

### DIFF
--- a/AssetsPickerViewController/Classes/Album/View/AssetsAlbumCell.swift
+++ b/AssetsPickerViewController/Classes/Album/View/AssetsAlbumCell.swift
@@ -99,6 +99,7 @@ open class AssetsAlbumCell: UICollectionViewCell, AssetsAlbumCellProtocol {
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
             make.height.equalTo(countLabel.font.pointSize + 2)
+	    make.bottom.equalTo(snp.bottom).offset(8)
         }
     }
 }

--- a/AssetsPickerViewController/Classes/Album/View/AssetsAlbumCell.swift
+++ b/AssetsPickerViewController/Classes/Album/View/AssetsAlbumCell.swift
@@ -99,7 +99,7 @@ open class AssetsAlbumCell: UICollectionViewCell, AssetsAlbumCellProtocol {
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
             make.height.equalTo(countLabel.font.pointSize + 2)
-	    make.bottom.equalTo(snp.bottom).offset(8)
+            make.bottom.equalTo(snp.bottom).offset(8)
         }
     }
 }


### PR DESCRIPTION
When overriding and using dynamic font, the count overlaps with the next album cell. Adding a bottom constraint prevents this and allows the layout to size correctly.