### PR TITLE
Album performance optimization

### DIFF
--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+Delegate.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+Delegate.swift
@@ -45,11 +45,12 @@ extension AssetsPhotoViewController: UIGestureRecognizerDelegate {
 }
 
 // MARK: - UIScrollViewDelegate
-//extension AssetsPhotoViewController: UIScrollViewDelegate {
-//    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+extension AssetsPhotoViewController: UIScrollViewDelegate {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
 //        logi("contentOffset: \(scrollView.contentOffset)")
-//    }
-//}
+        updateCachedAssets()
+    }
+}
 
 // MARK: - AssetsAlbumViewControllerDelegate
 extension AssetsPhotoViewController: AssetsAlbumViewControllerDelegate {

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+Setup.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+Setup.swift
@@ -81,6 +81,7 @@ extension AssetsPhotoViewController {
                 self.collectionView.reloadData()
                 self.preselectItemsIfNeeded(result: fetchResult)
                 self.scrollToLastItemIfNeeded()
+                self.updateCachedAssets(force: true)
                 // hide loading
                 self.loadingPlaceholderView.isHidden = true
                 self.loadingActivityIndicatorView.stopAnimating()

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+UI.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController+UI.swift
@@ -199,7 +199,7 @@ extension AssetsPhotoViewController {
         return titleString
     }
     
-    func updateCachedAssets() {
+    func updateCachedAssets(force: Bool = false) {
         let isViewVisible = isViewLoaded && view.window != nil
         
         if !isViewVisible {
@@ -215,11 +215,11 @@ extension AssetsPhotoViewController {
         // If scrolled by a "reasonable" amount...
         let delta = abs(preheatRect.midY - previousPreheatRect.midY)
         
-        if delta > (bounds.height / 3.0) {
+        if (delta > (bounds.height / 3.0)) || force {
             var addedIndexPaths: [IndexPath] = []
             var removedIndexPaths: [IndexPath] = []
             
-            computeDifferenceBetweenRect(previousPreheatRect, newRect: preheatRect, add: { (rect) in
+            computeDifferenceBetweenRect(previousPreheatRect, newRect: preheatRect, added: { (rect) in
                 let indexPaths = getIndexPathsForElements(in: rect)
                 addedIndexPaths.append(contentsOf: indexPaths)
             }) { (rect) in
@@ -262,7 +262,7 @@ extension AssetsPhotoViewController {
         return asstes
     }
     
-    func computeDifferenceBetweenRect(_ oldRect: CGRect, newRect: CGRect, add: (CGRect) -> Void, remove: (CGRect) -> Void) {
+    func computeDifferenceBetweenRect(_ oldRect: CGRect, newRect: CGRect, added: (CGRect) -> Void, removed: (CGRect) -> Void) {
         if newRect.intersects(oldRect) {
             let oldMaxY = oldRect.maxY
             let oldMinY = oldRect.minY
@@ -271,24 +271,24 @@ extension AssetsPhotoViewController {
             
             if newMaxY > oldMaxY {
                 let rect = CGRect(x: newRect.origin.x, y: oldMaxY, width: newRect.size.width, height: (newMaxY - oldMaxY))
-                add(rect)
+                added(rect)
             }
             if oldMinY > newMinY {
                 let rect = CGRect(x: newRect.origin.x, y: newMinY, width: newRect.size.width, height: oldMinY - newMinY)
-                add(rect)
+                added(rect)
             }
             if newMaxY < oldMaxY {
                 let rect = CGRect(x: newRect.origin.x, y: newMaxY, width: newRect.size.width, height: oldMaxY - newMaxY)
-                remove(rect)
+                removed(rect)
             }
             if oldMinY < newMinY {
                 let rect = CGRect(x: newRect.origin.x, y: oldMinY, width: newRect.size.width, height: newMinY - oldMinY)
-                remove(rect)
+                removed(rect)
             }
 
         } else {
-            add(newRect)
-            remove(oldRect)
+            added(newRect)
+            removed(oldRect)
         }
     }
 }

--- a/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
+++ b/AssetsPickerViewController/Classes/Photo/Controller/AssetsPhotoViewController.swift
@@ -247,7 +247,6 @@ open class AssetsPhotoViewController: UIViewController {
         if traitCollection.forceTouchCapability == .available {
             previewing = registerForPreviewing(with: self, sourceView: collectionView)
         }
-        updateCachedAssets()
     }
     
     override open func viewDidDisappear(_ animated: Bool) {
@@ -261,10 +260,6 @@ open class AssetsPhotoViewController: UIViewController {
     
     deinit {
         logd("Released \(type(of: self))")
-    }
-    
-    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        updateCachedAssets()
     }
 }
 


### PR DESCRIPTION
Optimize the internal method of `fetchAlbums(forAlbumType type:(` to fetch resources only for the default albums using the synchronous method, other albums are fetched asynchronously. This method is not perfect yet, but it has been tested and it works, all that needs to be done now is to update the album list view synchronously when the album information is fetched. I need more people to help me to improve this part of the code or to provide suggestions. Thank you very much.

https://github.com/DragonCherry/AssetsPickerViewController/issues/62
