### PR TITLE
Resolves objective-c issues while calling methods from objective-c classes

### DIFF
--- a/AssetsPickerViewController/Classes/Picker/AssetsPickerConfig.swift
+++ b/AssetsPickerViewController/Classes/Picker/AssetsPickerConfig.swift
@@ -9,7 +9,8 @@
 import UIKit
 import Photos
 
-open class AssetsPickerConfig {
+@objcMembers
+open class AssetsPickerConfig : NSObject {
 
     // MARK: - Localized Strings Config
 
@@ -93,6 +94,7 @@ open class AssetsPickerConfig {
     open var assetIsForcedSelectAssetFromCamera: Bool = true
     
     // MARK: Fetch
+    open var isVideoAllowed: Bool = false
     open var assetFetchOptions: [PHAssetCollectionType: PHFetchOptions]?
     
     // MARK: Custom Layout
@@ -126,7 +128,7 @@ open class AssetsPickerConfig {
         return CGSize(width: edge, height: edge)
     }
     
-    public init() {}
+    public override init() {}
     
     @discardableResult
     open func prepare() -> Self {
@@ -180,7 +182,11 @@ open class AssetsPickerConfig {
                 NSSortDescriptor(key: "creationDate", ascending: true),
                 NSSortDescriptor(key: "modificationDate", ascending: true)
             ]
-            options.predicate = NSPredicate(format: "mediaType = %d OR mediaType = %d", PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue)
+            options.predicate = NSPredicate(format: "mediaType = %d", PHAssetMediaType.image.rawValue)
+            if isVideoAllowed {
+                options.predicate = NSPredicate(format: "mediaType = %d OR mediaType = %d", PHAssetMediaType.image.rawValue, PHAssetMediaType.video.rawValue)
+            }
+            
             assetFetchOptions = [
                 .smartAlbum: options,
                 .album: options,

--- a/AssetsPickerViewController/Classes/Picker/Controller/AssetsPickerViewController.swift
+++ b/AssetsPickerViewController/Classes/Picker/Controller/AssetsPickerViewController.swift
@@ -22,6 +22,7 @@ import Photos
 }
 
 // MARK: - AssetsPickerViewController
+@objcMembers
 open class AssetsPickerViewController: UINavigationController {
     
     @objc open weak var pickerDelegate: AssetsPickerViewControllerDelegate?


### PR DESCRIPTION
added @objcMembers annotation in AssetsPickerConfig.swift & AssetsPickerViewController.swift files, so that it can be accessible from objective-c files. Also added isVideoAllowed variable to dynamically allow the user to fetch images and videos.